### PR TITLE
修改客户端API-flutter链接错误和修改快速入门（Electron）

### DIFF
--- a/yehe_doc/中间件与通信/即时通信 IM/客户端 API/SDK API（新版）/SDK API（Flutter）_intl_en.md
+++ b/yehe_doc/中间件与通信/即时通信 IM/客户端 API/SDK API（新版）/SDK API（Flutter）_intl_en.md
@@ -21,12 +21,12 @@ Use the following APIs for the sending and receiving of text and signaling (cust
 
 | API      | Description                         |
 |---------|---------|
-| [addSimpleMsgListener](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMManager/addSimpleMsgListener.html) | Sets an event listener for simple messages (text messages and custom messages). Do not confuse this API with the [addAdvancedMsgListener](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMMessageManager/addAdvancedMsgListener.html) API. |
-| [removeSimpleMsgListener](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMManager/removeSimpleMsgListener.html) | Removes the event listener for simple messages (text messages and custom messages). |
-| [sendC2CTextMessage](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMManager/sendC2CTextMessage.html) | Sends a one-to-one (C2C) text message. |
-| [sendC2CCustomMessage](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMManager/sendC2CCustomMessage.html) | Sends a one-to-one custom (signaling) message. |
-| [sendGroupTextMessage](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMManager/sendGroupTextMessage.html) | Sends a group text message. |
-| [sendGroupCustomMessage](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMManager/sendGroupCustomMessage.html) | Sends a group custom (signaling) message. |
+| [addSimpleMsgListener](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_manager/V2TIMManager/addSimpleMsgListener.html) | Sets an event listener for simple messages (text messages and custom messages). Do not confuse this API with the [addAdvancedMsgListener](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_message_manager/V2TIMMessageManager/addAdvancedMsgListener.html) API. |
+| [removeSimpleMsgListener](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_manager/V2TIMManager/removeSimpleMsgListener.html) | Removes the event listener for simple messages (text messages and custom messages). |
+| [sendC2CTextMessage](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_manager/V2TIMManager/sendC2CTextMessage.html) | Sends a one-to-one (C2C) text message. |
+| [sendC2CCustomMessage](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_manager/V2TIMManager/sendC2CCustomMessage.html) | Sends a one-to-one custom (signaling) message. |
+| [sendGroupTextMessage](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_manager/V2TIMManager/sendGroupTextMessage.html) | Sends a group text message. |
+| [sendGroupCustomMessage](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_manager/V2TIMManager/sendGroupCustomMessage.html) | Sends a group custom (signaling) message. |
 
 
 ## Signaling APIs
@@ -67,7 +67,7 @@ If you need to send or receive rich media messages (such as image, video, and fi
 | [removeAdvancedMsgListener](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMMessageManager/removeAdvancedMsgListener.html) | Removes the event listener for advanced messages. |
 | [getC2CHistoryMessageList](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMMessageManager/getC2CHistoryMessageList.html) | Gets the one-to-one message history. |
 | [getHistoryMessageList](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMMessageManager/getHistoryMessageList.html) | Gets the message history (advanced API). |
-| [getHistoryMessageListWithoutFormat](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMMessageManager/getHistoryMessageListWithoutFormat.html) | Gets the message history (advanced API) (without processing the data returned by native SDKs). |
+| [getHistoryMessageListWithoutFormat](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_message_manager/V2TIMMessageManager/getHistoryMessageListWithoutFormat.html) | Gets the message history (advanced API) (without processing the data returned by native SDKs). |
 | [getGroupHistoryMessageList](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMMessageManager/getGroupHistoryMessageList.html) | Gets the group message history. |
 | [markC2CMessageAsRead](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMMessageManager/markC2CMessageAsRead.html) | Marks a one-to-one message as read. |
 | [markGroupMessageAsRead](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMMessageManager/markGroupMessageAsRead.html) | Marks a group message as read. |
@@ -89,16 +89,16 @@ If you need to send or receive rich media messages (such as image, video, and fi
 | [sendMessage](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMMessageManager/sendMessage.html) | Sends a message. |
 | [sendReplyMessage](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMMessageManager/sendReplyMessage.html) | Sends a reply message. |
 | [searchLocalMessages](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMMessageManager/searchLocalMessages.html) | Searches for local messages. |
-| [findMessages](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMMessageManager/findMessages.html) | Queries local messages in a conversation by `messageID`. |
+| [findMessages](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_message_manager/V2TIMMessageManager/findMessages.html) | Queries local messages in a conversation by `messageID`. |
 |[sendMessageReadReceptes](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMMessageManager/sendMessageReadReceipts.html)| Sends group message read receipts. |
 |[getMessageReadReceptes](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMMessageManager/getMessageReadReceipts.html) | Gets read receipts for messages sent by yourself. |
 |[getgroupMessageReadMemeberList](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMMessageManager/getGroupMessageReadMemberList.html)| Gets the list of members who have (or have not) read a message sent by yourself. |
-| [~~sendCustomMessage~~](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMMessageManager/sendCustomMessage.html) | Sends a custom message (disused). |
-| [~~sendImageMessage~~](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMMessageManager/sendImageMessage.html) | Sends an image message (disused). |
-| [~~sendSoundMessage~~](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMMessageManager/sendSoundMessage.html) | Sends a audio message (disused). |
-|  [~~sendVideoMessage~~](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMMessageManager/sendVideoMessage.html) | Sends a video message (disused). |
-| [~~sendFileMessage~~](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMMessageManager/sendFileMessage.html) | Sends a file message (disused). |
-| [~~sendLocationMessage~~](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMMessageManager/sendLocationMessage.html) | Sends a location message (disused). |
+| [~~sendCustomMessage~~](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_message_manager/V2TIMMessageManager/sendCustomMessage.html) | Sends a custom message (disused). |
+| [~~sendImageMessage~~](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_message_manager/V2TIMMessageManager/sendImageMessage.html) | Sends an image message (disused). |
+| [~~sendSoundMessage~~](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_message_manager/V2TIMMessageManager/sendSoundMessage.html) | Sends a audio message (disused). |
+|  [~~sendVideoMessage~~](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_message_manager/V2TIMMessageManager/sendVideoMessage.html) | Sends a video message (disused). |
+| [~~sendFileMessage~~](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_message_manager/V2TIMMessageManager/sendFileMessage.html) | Sends a file message (disused). |
+| [~~sendLocationMessage~~](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_message_manager/V2TIMMessageManager/sendLocationMessage.html) | Sends a location message (disused). |
 
 
 ## Group APIs
@@ -148,7 +148,7 @@ The conversation list is the list a user sees on the first screen after logging 
 |---------|---------|
 | [setConversationListener](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMConversationManager/setConversationListener.html) | Sets a conversation listener. |
 | [getConversationList](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMConversationManager/getConversationList.html) | Gets the conversation list. |
-| [getConversationListWithoutFormat](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMConversationManager/getConversationListWithoutFormat.html) | Gets the conversation list (unformatted). |
+| [getConversationListWithoutFormat](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_conversation_manager/V2TIMConversationManager/getConversationListWithoutFormat.html) | Gets the conversation list (unformatted). |
 | [getConversationListByConversaionIds](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMConversationManager/getConversationListByConversaionIds.html) | Gets the list of specified conversations by conversation IDs. |
 | [pinConversation](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMConversationManager/pinConversation.html) | Pins a conversation to the top. |
 | [getTotalUnreadMessageCount](https://comm.qq.com/im/doc/flutter/en/SDKAPI/Api/V2TIMConversationManager/getTotalUnreadMessageCount.html) | Gets the total unread message count of a conversation. |

--- a/yehe_doc/中间件与通信/即时通信 IM/客户端 API/SDK API（新版）/SDK API（Flutter）_intl_zh.md
+++ b/yehe_doc/中间件与通信/即时通信 IM/客户端 API/SDK API（新版）/SDK API（Flutter）_intl_zh.md
@@ -21,12 +21,12 @@
 
 | API | 描述 |
 |---------|---------|
-| [addSimpleMsgListener](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMManager/addSimpleMsgListener.html) | 设置基本消息（文本消息和自定义消息）的事件监听器， 请不要同  [addAdvancedMsgListener](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/addAdvancedMsgListener.html)  混用 |
-| [removeSimpleMsgListener](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMManager/removeSimpleMsgListener.html) | 移除基本消息（文本消息和自定义消息）的事件监听器 |
-| [sendC2CTextMessage](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMManager/sendC2CTextMessage.html) | 发送单聊（C2C）普通文本消息 |
-| [sendC2CCustomMessage](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMManager/sendC2CCustomMessage.html) | 发送单聊（C2C）自定义（信令）消息 |
-| [sendGroupTextMessage](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMManager/sendGroupTextMessage.html) | 发送群聊普通文本消息 |
-| [sendGroupCustomMessage](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMManager/sendGroupCustomMessage.html) | 发送群聊自定义（信令）消息 |
+| [addSimpleMsgListener](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_manager/V2TIMManager/addSimpleMsgListener.html) | 设置基本消息（文本消息和自定义消息）的事件监听器， 请不要同  [addAdvancedMsgListener](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_message_manager/V2TIMMessageManager/addAdvancedMsgListener.html)  混用 |
+| [removeSimpleMsgListener](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_manager/V2TIMManager/removeSimpleMsgListener.html) | 移除基本消息（文本消息和自定义消息）的事件监听器 |
+| [sendC2CTextMessage](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_manager/V2TIMManager/sendC2CTextMessage.html) | 发送单聊（C2C）普通文本消息 |
+| [sendC2CCustomMessage](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_manager/V2TIMManager/sendC2CCustomMessage.html) | 发送单聊（C2C）自定义（信令）消息 |
+| [sendGroupTextMessage](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_manager/V2TIMManager/sendGroupTextMessage.html) | 发送群聊普通文本消息 |
+| [sendGroupCustomMessage](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_manager/V2TIMManager/sendGroupCustomMessage.html) | 发送群聊自定义（信令）消息 |
 
 
 ## 信令接口
@@ -63,11 +63,11 @@
 
 | API | 描述 |
 |---------|---------|
-| [addAdvancedMsgListener](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/addAdvancedMsgListener.html) | 设置高级消息的事件监听器， 请不要同 [addSimpleMsgListener](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMManager/addSimpleMsgListener.html) 混用 |
+| [addAdvancedMsgListener](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/addAdvancedMsgListener.html) | 设置高级消息的事件监听器， 请不要同 [addSimpleMsgListener](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_manager/V2TIMManager/addSimpleMsgListener.html) 混用 |
 | [removeAdvancedMsgListener](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/removeAdvancedMsgListener.html) | 移除高级消息的事件监听器 |
 | [getC2CHistoryMessageList](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/getC2CHistoryMessageList.html) | 获取单聊（C2C）历史消息 |
 | [getHistoryMessageList](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/getHistoryMessageList.html) | 获取历史消息高级接口 |
-| [getHistoryMessageListWithoutFormat](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/getHistoryMessageListWithoutFormat.html) | 获取历史消息高级接口(没有处理Native返回数据) |
+| [getHistoryMessageListWithoutFormat](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_message_manager/V2TIMMessageManager/getHistoryMessageListWithoutFormat.html) | 获取历史消息高级接口(没有处理Native返回数据) |
 | [getGroupHistoryMessageList](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/getGroupHistoryMessageList.html) | 获取群组历史消息 |
 | [markC2CMessageAsRead](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/markC2CMessageAsRead.html) | 设置单聊（C2C）消息已读 |
 | [markGroupMessageAsRead](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/markGroupMessageAsRead.html) | 设置群组消息已读 |
@@ -89,16 +89,16 @@
 | [sendMessage](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/sendMessage.html) | 发送消息 |
 | [sendReplyMessage](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/sendReplyMessage.html) | 发送回复消息 |
 | [searchLocalMessages](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/searchLocalMessages.html) | 搜索本地消息 |
-| [findMessages](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/findMessages.html) | 根据 messageID 查询指定会话中的本地消息 |
+| [findMessages](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_message_manager/V2TIMMessageManager/findMessages.html) | 根据 messageID 查询指定会话中的本地消息 |
 |[sendMessageReadReceptes](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/sendMessageReadReceipts.html)|发送群消息已读回执|
 |[getMessageReadReceptes](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/getMessageReadReceipts.html) |获取自己发送消息的已读回执|
 |[getgroupMessageReadMemeberList](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/getGroupMessageReadMemberList.html)|获取自己发送的群消息已读（未读）群成员列表|
-| [~~sendCustomMessage~~](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/sendCustomMessage.html) | 发送自定义消息(已废弃) |
-| [~~sendImageMessage~~](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/sendImageMessage.html) | 发送图片消息(已废弃) |
-| [~~sendSoundMessage~~](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/sendSoundMessage.html) | 发送语音消息(已废弃) |
-| [~~sendVideoMessage~~](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/sendVideoMessage.html) | 发送视频消息(已废弃) |
-| [~~sendFileMessage~~](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/sendFileMessage.html) | 发送文件消息(已废弃) |
-| [~~sendLocationMessage~~](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMMessageManager/sendLocationMessage.html) | 发送地理位置消息(已废弃) |
+| [~~sendCustomMessage~~](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_message_manager/V2TIMMessageManager/sendCustomMessage.html) | 发送自定义消息(已废弃) |
+| [~~sendImageMessage~~](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_message_manager/V2TIMMessageManager/sendImageMessage.html) | 发送图片消息(已废弃) |
+| [~~sendSoundMessage~~](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_message_manager/V2TIMMessageManager/sendSoundMessage.html) | 发送语音消息(已废弃) |
+| [~~sendVideoMessage~~](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_message_manager/V2TIMMessageManager/sendVideoMessage.html) | 发送视频消息(已废弃) |
+| [~~sendFileMessage~~](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_message_manager/V2TIMMessageManager/sendFileMessage.html) | 发送文件消息(已废弃) |
+| [~~sendLocationMessage~~](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_message_manager/V2TIMMessageManager/sendLocationMessage.html) | 发送地理位置消息(已废弃) |
 
 
 ## 群组相关接口
@@ -125,7 +125,7 @@
 | [deleteGroupAttributes](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMGroupManager/deleteGroupAttributes.html) | 删除指定群属性，keys 传 null 则清空所有群属性。 |
 | [getGroupAttributes](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMGroupManager/getGroupAttributes.html) | 获取指定群属性，keys 传 null 则获取所有群属性。 |
 | [searchGroups](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMGroupManager/searchGroups.html) | 搜索群列表 |
-| [searchGroupByID](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMGroupManager/searchGroupByID.html) | 通过 groupID 搜索群组 |
+| [searchGroupByID](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_group_manager/V2TIMGroupManager/searchGroupByID.html) | 通过 groupID 搜索群组 |
 | [getGroupOnlineMemberCount](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMGroupManager/getGroupOnlineMemberCount.html) | 获取指定群在线人数(目前只支持直播群) |
 | [getGroupMemberList](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMGroupManager/getGroupMemberList.html) | 获取群成员列表 |
 | [getGroupMembersInfo](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMGroupManager/getGroupMembersInfo.html) | 获取指定的群成员资料 |
@@ -148,8 +148,8 @@
 |---------|---------|
 | [setConversationListener](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMConversationManager/setConversationListener.html) | 设置会话监听器 |
 | [getConversationList](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMConversationManager/getConversationList.html) | 获取会话列表 |
-| [getConversationListWithoutFormat](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMConversationManager/getConversationListWithoutFormat.html) | 获取会话列表（无格式化） |
-| [getConversationListByConversaionIds](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMConversationManager/getConversationListByConversaionIds.html) | 通过会话ID获取指定会话列表 |
+| [getConversationListWithoutFormat](https://pub.dev/documentation/tencent_im_sdk_plugin/latest/manager_v2_tim_conversation_manager/V2TIMConversationManager/getConversationListWithoutFormat.html) | 获取会话列表（无格式化） |
+| [getConversationListByConversaionIds](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMConversationManager/getConversationListByFilter.html) | 通过会话ID获取指定会话列表 |
 | [pinConversation](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMConversationManager/pinConversation.html) | 会话置顶 |
 | [getTotalUnreadMessageCount](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMConversationManager/getTotalUnreadMessageCount.html) | 获取会话未读总数 |
 | [getConversation](https://comm.qq.com/im/doc/flutter/zh/SDKAPI/Api/V2TIMConversationManager/getConversation.html) | 获取指定会话 |

--- a/yehe_doc/中间件与通信/即时通信 IM/快速入门/快速入门（Electron）_intl_zh.md
+++ b/yehe_doc/中间件与通信/即时通信 IM/快速入门/快速入门（Electron）_intl_zh.md
@@ -235,5 +235,3 @@ Dynamic Linking Error. electron-builder 配置
 
 ## 联系我们
 - 如果您在介入使用过程中有任何疑问，请加入 QQ 群：753897823 咨询。
-- 开发群 
-<img src="https://qcloudimg.tencent-cloud.cn/raw/a85a8b1642c59d672e960f96cd08b2ae.jpg" width="400" height="500" alt="二维码"/> 

--- a/yehe_doc/中间件与通信/即时通信 IM/快速入门/快速入门（Electron）_intl_zh.md
+++ b/yehe_doc/中间件与通信/即时通信 IM/快速入门/快速入门（Electron）_intl_zh.md
@@ -1,71 +1,239 @@
-本文主要介绍如何快速运行腾讯云即时通信 IM Demo（Electron）。
+本文主要介绍如何快速运行腾讯云即时通信 IM Demo（Electron）并了解集成 Electron SDK 的方法。
 
 ## 环境要求
 
-| 平台 | 版本 |
-|---------|---------|
+| 平台  | 版本  |
+| --- | --- |
 | Electron | 13.1.5 及以上版本。 |
-|Node.js|v14.2.0|
+| Node.js | v14.2.0 |
+
+## 支持平台
+
+目前支持 Macos 和 Windows 两个平台。
+
+## 体验 DEMO
+
+在开始接入前，您可以体验我们的 [DEMO](https://cloud.tencent.com/document/product/269/36852) ，快速了解腾讯云 IM Electron SDK。
 
 ## 前提条件
 
-您已 [注册腾讯云](https://intl.cloud.tencent.com/document/product/378/17985) 帐号，并完成 [实名认证](https://intl.cloud.tencent.com/document/product/378/3629)。
+您已 [注册腾讯云](https://cloud.tencent.com/document/product/378/17985) 帐号，并完成 [实名认证](https://cloud.tencent.com/document/product/378/3629)。
 
 ## 操作步骤
+
 [](id:step1)
 
 ### 步骤1：创建应用
+
 1. 登录 [即时通信 IM 控制台](https://console.cloud.tencent.com/im)。
->?如果您已有应用，请记录其 SDKAppID 并 [获取密钥信息](#step2)。
->同一个腾讯云帐号，最多可创建300个即时通信 IM 应用。若已有300个应用，您可以先 [停用并删除](https://intl.cloud.tencent.com/document/product/1047/34540) 无需使用的应用后再创建新的应用。**应用删除后，该 SDKAppID 对应的所有数据和服务不可恢复，请谨慎操作。**
->
+  > ?如果您已有应用，请记录其 SDKAppID 并 [获取密钥信息](#step2)。
+  > 同一个腾讯云帐号，最多可创建300个即时通信 IM 应用。若已有300个应用，您可以先 [停用并删除](https://cloud.tencent.com/document/product/269/32578#.E5.81.9C.E7.94.A8.2F.E5.88.A0.E9.99.A4.E5.BA.94.E7.94.A8) 无需使用的应用后再创建新的应用。**应用删除后，该 SDKAppID 对应的所有数据和服务不可恢复，请谨慎操作。**
 2. 单击**创建新应用**，在**创建应用**对话框中输入您的应用名称，单击**确定**。
-![](https://main.qcloudimg.com/raw/15e61a874a0640d517eeb67e922a14bc.png)
+  ![](https://qcloudimg.tencent-cloud.cn/raw/febed2f15dee6ff09f066ba228c7fc27.png)
 3. 请保存 SDKAppID 信息。可在控制台总览页查看新建应用的状态、业务版本、SDKAppID、标签、创建时间以及到期时间。
-    ![](https://main.qcloudimg.com/raw/7954cc2882d050f68cd5d1df2ee776a6.png)
+   ![](https://main.qcloudimg.com/raw/ed34d9294a485d8d06b3bb7e0cc5ae59.png) 
 4. 单击创建后的应用，左侧导航栏单击**辅助工具**>**UserSig 生成&校验**，创建一个 UserID 及其对应的 UserSig，复制签名信息，后续登录使用。
-![](https://main.qcloudimg.com/raw/2286644d987d24caf565142ae30c4392.png)
+  ![](https://main.qcloudimg.com/raw/8315da2551bf35ec85ce10fd31fe2f52.png)
 
 [](id:step2)
-### 步骤2：下载源码安装依赖并运行
+
+
+### 步骤2：选择适合的方法集成 Electron SDK
+IM 提供了两种方式来即成，您可以选择最合适的方案来即成：
+
+| 继承方式 | 适用场景 |
+| --- | --- |
+| 使用 DEMO | IM Demo包含完整的聊天功能，代码已开源，如果您需要实现聊天类似场景，可以使用 Demo进行二次开发。可立即体验 [Demo](https://cloud.tencent.com/document/product/269/36852)。 |
+| 自实现 | 如果 Demo 不能满足您应用的功能界面需求，可以使用该方法。 |
+
+为帮助您更好的理解 IM SDK 的各 API，我们还提供了 [API 文档](https://comm.qq.com/im/doc/electron/zh/)。
+
+
+[](id:step3)
+### 步骤3：使用 Demo
+
 1. 克隆即时通信 IM Electron Demo 源码到本地。
-```javascript
-git clone https://github.com/tencentyun/im_electron_demo.git
-```
-
+  ```javascript
+  git clone https://github.com/tencentyun/im_electron_demo.git
+  ```
 2. 安装项目依赖。
-```javascript
-// 项目根目录
-npm install
-
-// 渲染进程目录
-cd src/client
-npm install
-```
-
+  ```javascript
+  // 项目根目录
+  npm install
+    
+  // 渲染进程目录
+  cd src/client
+  npm install
+  ```
 3. 项目运行。
 ```javascript
 // 项目根目录
 npm start
 ```
-
 4. 项目打包。
+  ```javascript
+  // mac打包
+  npm run build:mac
+  // windows打包
+  npm run build:windows
+  ```
+	
+[](id:step4)
+### 步骤4：自实现
+**安装 Electron SDK**
+使用如下命令，安装 Electron SDK最新版本
+在命令行执行：
+```
+npm install im_electron_sdk
+```
+**完成 SDK 初始化**
+1. 在 `TimMain`中传入您的`sdkAppID`。
 ```javascript
-// mac打包
-npm run build:mac
-// windows打包
-npm run build:windows
+// 主进程
+const TimMain = require('im_electron_sdk/dist/main')
+
+const sdkappid = 0;// 可以去腾讯云即时通信IM控制台申请
+const tim = new TimMain({
+  sdkappid:sdkappid
+})
+```
+2. 调用`TIMInit`，完成 SDK 初始化
+```javascript
+//渲染进程
+const TimRender = require('im_electron_sdk/dist/render')
+const timRender = new TimRender();
+// 初始化
+timRender.TIMInit()
+```
+3. 登录测试用户
+此时，您可以使用最开始的时候，在控制台申城的测试账户，完成登录验证。
+调用`timRender.TIMLogin`方法，登录一个测试用户。
+当返回值 `code`为0时，登录成功。
+```javascript
+const TimRender = require('im_electron_sdk/dist/render')
+const timRender = new TimRender();
+let {code} = await timRender.TIMLogin({
+  userID:"userID",
+  userSig:"userSig" // 参考userSig生成
+})
+```
+>? 该账户仅限开发测试使用，应用上线前，正确的`UserSig` 签发方式是将`UserSig`的计算代码集成到您的服务端，并提供面向 APP的接口。在需要 `UserSig`时由您的 APP 向业务服务器发起请求获取动态 `UserSig`。更多详情请参见 [服务端生成UserSig](https://cloud.tencent.com/document/product/269/32688#GeneratingdynamicUserSig)。
+
+**发送信息**
+此处以发送文本消息距离，`code`返回 0 则为消息发送成功。
+代码示例：
+```javascript
+const TimRender = require('im_electron_sdk/dist/render')
+const timRender = new TimRender();
+let param:MsgSendMessageParamsV2 = {    // param of TIMMsgSendMessage
+    conv_id: "conv_id",
+    conv_type: 1,
+    params: {
+        message_elem_array: [{
+            elem_type: 1,
+            text_elem_content:'Hello Tencent!',
+
+        }],
+        message_sender: "senderID",
+    },
+    callback: (data) => {}
+  }
+let {code} = await timRender.TIMMsgSendMessageV2(param);
+```
+>? 如果发送失败，可能是由于您的 sdkAppID 不支持陌生人发送消息，您可至控制台开启，用于测试。[请点击此链接](https://console.cloud.tencent.com/im/login-message)，关闭好友关系链检查。
+
+**获取会话列表**
+在上一个步骤中，完成发送测试消息，现在可登录另一个测试账户，拉取会话列表。
+常见应用场景为：
+在启动应用程序后立即获取会话列表，然后监听长链接以实时更新会话列表的变化。
+```javascript
+let param:getConvList = {
+            userData:userData,
+        }
+let data:commonResult<convInfo[]> = await timRenderInstance.TIMConvGetConvList(param)
+```
+此时，您可以看到您在上一步中，使用另一个测试账号发来的消息的会话。
+
+**接收消息**
+常见应用场景为：
+1. 界面进入新的会话后，首先一次性请求一定数量的历史消息，用于展示历史消息列表。
+2. 监听长链接，实时接收新的消息，将其添加进历史消息列表中。
+
+一次性请求历史消息列表
+```javascript
+let param:MsgGetMsgListParams = {
+        conv_id: conv_id,
+        conv_type: conv_type,
+        params: {
+            msg_getmsglist_param_last_msg: msg,
+            msg_getmsglist_param_count: 20,
+            msg_getmsglist_param_is_remble: true,
+        },
+        user_data: user_data
+    }
+    let msgList:commonResult<Json_value_msg[]> = await timRenderInstance.TIMMsgGetMsgList(param);
 ```
 
+监听实时获取新消息
+绑定 callback 示例代码如下：
+```javascript
+let param : TIMRecvNewMsgCallbackParams = {
+            callback: (...args)=>{},
+            user_data: user_data
+        }
+timRenderInstance.TIMAddRecvNewMsgCallback(param);
+```
 
+此时，您已基本完成 IM 模块开发，可以发送接收消息，也可以进入不同的会话。
+您可以继续完成 群组，用户资料，关系链，离线推送，本地搜索 等相关功能开发。
+详情可查看 [API 文档](https://comm.qq.com/im/doc/electron/zh/Callback/readme.html)
+
+[](id:step5)
+### 步骤5：使用更多插件丰富 IM 使用体验
+除 SDK 基础功能外，我们还提供了选装插件，帮助您丰富 IM 能力。
+- [音视频通话插件](https://cloud.tencent.com/document/product/647)：支持一对一/群组 音视频 通话。
+- [地理位置消息插件](https://cloud.tencent.com/document/product/269/80881) ：提供选取位置/发送位置及解析展示位置消息的能力。
+- [自定义表情插件](https://cloud.tencent.com/document/product/269/80882) ：快速便捷集成表情能力。
 
 ## 常见问题
 
-### 支持哪些平台？
+#### 支持哪些平台？
+
 目前支持 Macos 和 Windows 两个平台。
 
-### 安装开发环境问题，出现`gypgyp ERR!ERR`错误如何解决？
+#### 错误码如何查询？
+
+IM SDK 的 API 层面错误码，请查看 [错误码](https://cloud.tencent.com/document/product/269/1671)。
+
+#### 安装开发环境问题，出现 `gypgyp ERR!ERR` 错误如何解决？
+
 请参见 [gypgyp ERR!ERR! ](https://stackoverflow.com/questions/57879150/how-can-i-solve-error-gypgyp-errerr-find-vsfind-vs-msvs-version-not-set-from-c)。
 
-### Mac 端执行`npm run start` 会出现白屏，如何解决？
+#### Mac 端 Demo 执行 `npm run start` 会出现白屏，如何解决？
+
 Mac 端执行`npm run start` 会出现白屏，原因是渲染进程的代码还没有 build 完成，主进程打开的3000端口为空页面，当渲染进程代码 build 完成重新刷新窗口后即可解决问题。或者执行`cd src/client && npm run dev:react`, `npm run dev:electron`, 分开启动渲染进程和主进程。
+
+#### `vue-cli-plugin-electron-builder` 构建的项目如何使用 `native modules`?
+使用`vue-cli-plugin-electron-builder` 构建的项目使用`native modules` 请参见 [No native build was found for platform = xxx](https://github.com/nklayman/vue-cli-plugin-electron-builder/issues/1492)。
+
+#### 用 `webpack` 构建的项目如何使用 `native modules`?
+自己使用webpack 构建的项目使用native modules 请参见 [Windows 下常见问题](https://blog.csdn.net/Yoryky/article/details/106780254)。
+
+#### 出现 `Dynamic Linking Error`?
+Dynamic Linking Error. electron-builder 配置
+``` javascript
+   extraFiles:[
+    {
+      "from": "./node_modules/im_electron_sdk/lib/",
+      "to": "./Resources",
+      "filter": [
+        "**/*"
+      ]
+    }
+  ]
+```
+
+## 联系我们
+- 如果您在介入使用过程中有任何疑问，请加入 QQ 群：753897823 咨询。
+- 开发群 
+<img src="https://qcloudimg.tencent-cloud.cn/raw/a85a8b1642c59d672e960f96cd08b2ae.jpg" width="400" height="500" alt="二维码"/> 


### PR DESCRIPTION
修改客户端API-flutter链接错误和修改快速入门（Electron）
其中快速入门只修改了简体中文，其他语言需要翻译